### PR TITLE
Fix typo in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ Samples for RPA courses on [AutomationAcademy.com](https://automationacademy.com
 # Installation
 
 You should have account on [WorkFusion Knowledge Base](https://kb.workfusion.com/display/START/WorkFusion+Knowledge+Base) to access these links.
-* [WF Studio instalation](https://kb.workfusion.com/display/WF/Installation+and+Update)
+* [WF Studio installation](https://kb.workfusion.com/display/WF/Installation+and+Update)
 * [Importing project into WF Studio](https://kb.workfusion.com/display/WF/Setup+WorkFusion+Samples+Project+from+GitHub)
 * [RPA installation](https://kb.workfusion.com/display/RPA/RPA+Environment+Setup)
 


### PR DESCRIPTION
There is only one "l" in WF Studio instalation item of Installation section in readme.md.